### PR TITLE
RFC: traffic_ctl stop --drain

### DIFF
--- a/cmd/traffic_manager/traffic_manager.cc
+++ b/cmd/traffic_manager/traffic_manager.cc
@@ -167,6 +167,16 @@ is_server_idle()
 }
 
 static bool
+is_server_draining()
+{
+  RecInt draining = 0;
+  if (RecGetRecordInt("proxy.node.config.draining", &draining) != REC_ERR_OKAY) {
+    return false;
+  }
+  return draining != 0;
+}
+
+static bool
 waited_enough()
 {
   RecInt timeout = 0;
@@ -693,6 +703,8 @@ main(int argc, const char **argv)
   RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.manager", 0, RECP_NON_PERSISTENT);
   RecRegisterStatInt(RECT_NODE, "proxy.node.config.restart_required.cop", 0, RECP_NON_PERSISTENT);
 
+  RecRegisterStatInt(RECT_NODE, "proxy.node.config.draining", 0, RECP_NON_PERSISTENT);
+
   binding = new BindingInstance;
   metrics_binding_initialize(*binding);
   metrics_binding_configure(*binding);
@@ -738,6 +750,9 @@ main(int argc, const char **argv)
       ::exit(0);
       break;
     case MGMT_PENDING_IDLE_RESTART:
+      if (!is_server_draining()) {
+        lmgmt->processDrain();
+      }
       if (is_server_idle() || waited_enough()) {
         lmgmt->mgmtShutdown();
         ::exit(0);
@@ -748,8 +763,23 @@ main(int argc, const char **argv)
       lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
       break;
     case MGMT_PENDING_IDLE_BOUNCE:
+      if (!is_server_draining()) {
+        lmgmt->processDrain();
+      }
       if (is_server_idle() || waited_enough()) {
         lmgmt->processBounce();
+        lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
+      }
+    case MGMT_PENDING_STOP:
+      lmgmt->processShutdown();
+      lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
+      break;
+    case MGMT_PENDING_IDLE_STOP:
+      if (!is_server_draining()) {
+        lmgmt->processDrain();
+      }
+      if (is_server_idle() || waited_enough()) {
+        lmgmt->processShutdown();
         lmgmt->mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
       }
       break;

--- a/doc/admin-guide/files/records.config.en.rst
+++ b/doc/admin-guide/files/records.config.en.rst
@@ -411,6 +411,19 @@ Thread Variables
    This setting specifies the number of active client connections
    for use by :option:`traffic_ctl server restart --drain`.
 
+.. ts:cv:: CONFIG proxy.config.restart.stop_listening INT 0
+   :reloadable:
+
+   This option specifies whether |TS| should close listening sockets while shutting down gracefully.
+
+   ===== ======================================================================
+   Value Description
+   ===== ======================================================================
+   ``0`` Listening sockets will be kept open.
+   ``1`` Listening sockets will be closed when |TS| starts shuting down.
+   ===== ======================================================================
+
+
 .. ts:cv:: CONFIG proxy.config.stop.shutdown_timeout INT 0
    :reloadable:
 

--- a/iocore/net/I_NetProcessor.h
+++ b/iocore/net/I_NetProcessor.h
@@ -152,6 +152,7 @@ public:
 
   */
   virtual Action *main_accept(Continuation *cont, SOCKET listen_socket_in, AcceptOptions const &opt = DEFAULT_ACCEPT_OPTIONS);
+  virtual void stop_accept();
 
   /**
     Open a NetVConnection for connection oriented I/O. Connects

--- a/iocore/net/P_NetAccept.h
+++ b/iocore/net/P_NetAccept.h
@@ -98,6 +98,7 @@ struct NetAccept : public Continuation {
   void init_accept_loop(const char *);
   virtual void init_accept(EThread *t = nullptr);
   virtual void init_accept_per_thread();
+  virtual void stop_accept();
   virtual NetAccept *clone() const;
 
   // 0 == success

--- a/iocore/net/UnixNetAccept.cc
+++ b/iocore/net/UnixNetAccept.cc
@@ -202,6 +202,15 @@ NetAccept::init_accept_per_thread()
   }
 }
 
+void
+NetAccept::stop_accept()
+{
+  if (!action_->cancelled) {
+    action_->cancel();
+  }
+  server.close();
+}
+
 int
 NetAccept::do_listen(bool non_blocking)
 {

--- a/iocore/net/UnixNetProcessor.cc
+++ b/iocore/net/UnixNetProcessor.cc
@@ -196,6 +196,14 @@ UnixNetProcessor::accept_internal(Continuation *cont, int fd, AcceptOptions cons
   return na->action_.get();
 }
 
+void
+NetProcessor::stop_accept()
+{
+  for (auto na = naVec.begin(); na != naVec.end(); ++na) {
+    (*na)->stop_accept();
+  }
+}
+
 Action *
 UnixNetProcessor::connect_re_internal(Continuation *cont, sockaddr const *target, NetVCOptions *opt)
 {

--- a/iocore/net/UnixNetVConnection.cc
+++ b/iocore/net/UnixNetVConnection.cc
@@ -1101,11 +1101,6 @@ UnixNetVConnection::acceptEvent(int event, Event *e)
 
   thread = t;
 
-  if (action_.cancelled) {
-    free(thread);
-    return EVENT_DONE;
-  }
-
   // Send this NetVC to NetHandler and start to polling read & write event.
   if (h->startIO(this) < 0) {
     free(t);

--- a/mgmt/BaseManager.h
+++ b/mgmt/BaseManager.h
@@ -70,6 +70,7 @@
 // case statement.
 #define MGMT_EVENT_STORAGE_DEVICE_CMD_OFFLINE 10011
 #define MGMT_EVENT_LIFECYCLE_MESSAGE 10012
+#define MGMT_EVENT_DRAIN 10013
 
 /***********************************************************************
  *

--- a/mgmt/LocalManager.cc
+++ b/mgmt/LocalManager.cc
@@ -99,6 +99,14 @@ LocalManager::processBounce()
 }
 
 void
+LocalManager::processDrain()
+{
+  mgmt_log("[LocalManager::processDrain] Executing process drain request.\n");
+  signalEvent(MGMT_EVENT_DRAIN, "processDrain");
+  return;
+}
+
+void
 LocalManager::rollLogFiles()
 {
   mgmt_log("[LocalManager::rollLogFiles] Log files are being rolled.\n");

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -48,8 +48,10 @@ enum ManagementPendingOperation {
   MGMT_PENDING_NONE,         // Do nothing
   MGMT_PENDING_RESTART,      // Restart TS and TM
   MGMT_PENDING_BOUNCE,       // Restart TS
+  MGMT_PENDING_STOP,         // Stop TS
   MGMT_PENDING_IDLE_RESTART, // Restart TS and TM when TS is idle
-  MGMT_PENDING_IDLE_BOUNCE   // Restart TS when TS is idle
+  MGMT_PENDING_IDLE_BOUNCE,  // Restart TS when TS is idle
+  MGMT_PENDING_IDLE_STOP     // Stop TS when TS is idle
 };
 
 class LocalManager : public BaseManager
@@ -83,6 +85,7 @@ public:
   void processShutdown(bool mainThread = false);
   void processRestart();
   void processBounce();
+  void processDrain();
   void rollLogFiles();
   void clearStats(const char *name = NULL);
 

--- a/mgmt/LocalManager.h
+++ b/mgmt/LocalManager.h
@@ -95,7 +95,8 @@ public:
   int proxy_launch_count                               = 0;
   bool proxy_launch_outstanding                        = false;
   ManagementPendingOperation mgmt_shutdown_outstanding = MGMT_PENDING_NONE;
-  int proxy_running                                    = 0;
+  time_t mgmt_shutdown_triggered_at;
+  int proxy_running = 0;
   HttpProxyPort::Group m_proxy_ports;
   // Local inbound addresses to bind, if set.
   IpAddr m_inbound_ip4;

--- a/mgmt/ProcessManager.cc
+++ b/mgmt/ProcessManager.cc
@@ -381,6 +381,9 @@ ProcessManager::handleMgmtMsgFromLM(MgmtMessageHdr *mh)
   case MGMT_EVENT_RESTART:
     signalMgmtEntity(MGMT_EVENT_RESTART);
     break;
+  case MGMT_EVENT_DRAIN:
+    signalMgmtEntity(MGMT_EVENT_DRAIN);
+    break;
   case MGMT_EVENT_CLEAR_STATS:
     signalMgmtEntity(MGMT_EVENT_CLEAR_STATS);
     break;

--- a/mgmt/RecordsConfig.cc
+++ b/mgmt/RecordsConfig.cc
@@ -136,6 +136,8 @@ static const RecordElement RecordsConfig[] =
   ,
   {RECT_CONFIG, "proxy.config.restart.active_client_threshold", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_NULL, nullptr, RECA_NULL}
   ,
+  {RECT_CONFIG, "proxy.config.restart.stop_listening", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_INT, "[0-1]", RECA_NULL}
+  ,
   {RECT_CONFIG, "proxy.config.stop.shutdown_timeout", RECD_INT, "0", RECU_DYNAMIC, RR_NULL, RECC_STR, "^[0-9]+$", RECA_NULL}
   ,
 

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -423,6 +423,20 @@ Bounce(unsigned options)
 }
 
 /*-------------------------------------------------------------------------
+ * Stop
+ *-------------------------------------------------------------------------
+ * Stops traffic_server process(es).
+ */
+TSMgmtError
+Stop(unsigned options)
+{
+  lmgmt->mgmt_shutdown_triggered_at = time(nullptr);
+  lmgmt->mgmt_shutdown_outstanding = (options & TS_STOP_OPT_DRAIN) ? MGMT_PENDING_IDLE_STOP : MGMT_PENDING_STOP;
+
+  return TS_ERR_OKAY;
+}
+
+/*-------------------------------------------------------------------------
  * StorageDeviceCmdOffline
  *-------------------------------------------------------------------------
  * Disable a storage device.

--- a/mgmt/api/CoreAPI.cc
+++ b/mgmt/api/CoreAPI.cc
@@ -402,7 +402,8 @@ Reconfigure()
 TSMgmtError
 Restart(unsigned options)
 {
-  lmgmt->mgmt_shutdown_outstanding = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_RESTART : MGMT_PENDING_RESTART;
+  lmgmt->mgmt_shutdown_triggered_at = time(nullptr);
+  lmgmt->mgmt_shutdown_outstanding  = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_RESTART : MGMT_PENDING_RESTART;
 
   return TS_ERR_OKAY;
 }
@@ -415,7 +416,8 @@ Restart(unsigned options)
 TSMgmtError
 Bounce(unsigned options)
 {
-  lmgmt->mgmt_shutdown_outstanding = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_BOUNCE : MGMT_PENDING_BOUNCE;
+  lmgmt->mgmt_shutdown_triggered_at = time(nullptr);
+  lmgmt->mgmt_shutdown_outstanding  = (options & TS_RESTART_OPT_DRAIN) ? MGMT_PENDING_IDLE_BOUNCE : MGMT_PENDING_BOUNCE;
 
   return TS_ERR_OKAY;
 }

--- a/mgmt/api/CoreAPI.h
+++ b/mgmt/api/CoreAPI.h
@@ -46,6 +46,7 @@ TSMgmtError ServerBacktrace(unsigned options, char **trace);
 TSMgmtError Reconfigure();                                                         // TS reread config files
 TSMgmtError Restart(unsigned options);                                             // restart TM
 TSMgmtError Bounce(unsigned options);                                              // restart traffic_server
+TSMgmtError Stop(unsigned options);                                                // stop traffic_server
 TSMgmtError StorageDeviceCmdOffline(const char *dev);                              // Storage device operation.
 TSMgmtError LifecycleMessage(const char *tag, void const *data, size_t data_size); // Lifecycle alert to plugins.
 

--- a/mgmt/api/CoreAPIRemote.cc
+++ b/mgmt/api/CoreAPIRemote.cc
@@ -433,6 +433,23 @@ Bounce(unsigned options)
 }
 
 /*-------------------------------------------------------------------------
+ * Stop
+ *-------------------------------------------------------------------------
+ * Restart the traffic_server process(es) only.
+ */
+TSMgmtError
+Stop(unsigned options)
+{
+  TSMgmtError ret;
+  OpType optype        = OpType::STOP;
+  MgmtMarshallInt oval = options;
+
+  ret = MGMTAPI_SEND_MESSAGE(main_socket_fd, OpType::STOP, &optype, &oval);
+
+  return (ret == TS_ERR_OKAY) ? parse_generic_response(OpType::STOP, main_socket_fd) : ret;
+}
+
+/*-------------------------------------------------------------------------
  * StorageDeviceCmdOffline
  *-------------------------------------------------------------------------
  * Disable a storage device.

--- a/mgmt/api/INKMgmtAPI.cc
+++ b/mgmt/api/INKMgmtAPI.cc
@@ -1674,6 +1674,12 @@ TSBounce(unsigned options)
 }
 
 tsapi TSMgmtError
+TSStop(unsigned options)
+{
+  return Stop(options);
+}
+
+tsapi TSMgmtError
 TSStorageDeviceCmdOffline(const char *dev)
 {
   return StorageDeviceCmdOffline(dev);

--- a/mgmt/api/NetworkMessage.cc
+++ b/mgmt/api/NetworkMessage.cc
@@ -192,6 +192,7 @@ send_mgmt_error(int fd, OpType optype, TSMgmtError error)
   // Switch on operations, grouped by response format.
   switch (optype) {
   case OpType::BOUNCE:
+  case OpType::STOP:
   case OpType::EVENT_RESOLVE:
   case OpType::LIFECYCLE_MESSAGE:
   case OpType::PROXY_STATE_SET:

--- a/mgmt/api/NetworkMessage.h
+++ b/mgmt/api/NetworkMessage.h
@@ -41,6 +41,7 @@ enum class OpType : MgmtMarshallInt {
   RECONFIGURE,
   RESTART,
   BOUNCE,
+  STOP,
   EVENT_RESOLVE,
   EVENT_GET_MLT,
   EVENT_ACTIVE,

--- a/mgmt/api/TSControlMain.cc
+++ b/mgmt/api/TSControlMain.cc
@@ -639,6 +639,28 @@ handle_restart(int fd, void *req, size_t reqlen)
 }
 
 /**************************************************************************
+ * handle_stop
+ *
+ * purpose: handles request to stop TS
+ * output: TS_ERR_xx
+ * note: None
+ *************************************************************************/
+static TSMgmtError
+handle_stop(int fd, void *req, size_t reqlen)
+{
+  OpType optype;
+  MgmtMarshallInt options;
+  MgmtMarshallInt err;
+
+  err = recv_mgmt_request(req, reqlen, OpType::STOP, &optype, &options);
+  if (err == TS_ERR_OKAY) {
+    err = Stop(options);
+  }
+
+  return send_mgmt_response(fd, OpType::STOP, &err);
+}
+
+/**************************************************************************
  * handle_storage_device_cmd_offline
  *
  * purpose: handle storage offline command.
@@ -996,6 +1018,7 @@ static const control_message_handler handlers[] = {
   /* RECONFIGURE                */ {MGMT_API_PRIVILEGED, handle_reconfigure},
   /* RESTART                    */ {MGMT_API_PRIVILEGED, handle_restart},
   /* BOUNCE                     */ {MGMT_API_PRIVILEGED, handle_restart},
+  /* STOP                       */ {MGMT_API_PRIVILEGED, handle_stop},
   /* EVENT_RESOLVE              */ {MGMT_API_PRIVILEGED, handle_event_resolve},
   /* EVENT_GET_MLT              */ {0, handle_event_get_mlt},
   /* EVENT_ACTIVE               */ {0, handle_event_active},

--- a/mgmt/api/include/mgmtapi.h
+++ b/mgmt/api/include/mgmtapi.h
@@ -328,6 +328,11 @@ typedef enum {
   TS_RESTART_OPT_DRAIN = 0x02, /* Wait for traffic to drain before restarting. */
 } TSRestartOptionT;
 
+typedef enum {
+  TS_STOP_OPT_NONE = 0x0,
+  TS_STOP_OPT_DRAIN, /* Wait for traffic to drain before stopping. */
+} TSStopOptionT;
+
 /***************************************************************************
  * Structures
  ***************************************************************************/
@@ -828,6 +833,12 @@ tsapi TSMgmtError TSActionDo(TSActionNeedT action);
  * Output TSMgmtError
  */
 tsapi TSMgmtError TSBounce(unsigned options);
+
+/* TSStop: stop the traffic_server process(es).
+ * Input: options - bitmask of TSRestartOptionT
+ * Output TSMgmtError
+ */
+tsapi TSMgmtError TSStop(unsigned options);
 
 /* TSStorageDeviceCmdOffline: Request to make a cache storage device offline.
  * @arg dev Target device, specified by path to device.

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -76,6 +76,7 @@ extern "C" int plock(int);
 #include "ProxyConfig.h"
 #include "HttpProxyServerMain.h"
 #include "HttpBodyFactory.h"
+#include "ProxyClientSession.h"
 #include "logging/Log.h"
 #include "CacheControl.h"
 #include "IPAllow.h"
@@ -279,7 +280,8 @@ public:
       REC_ReadConfigInteger(timeout, "proxy.config.stop.shutdown_timeout");
 
       if (timeout) {
-        http2_drain = true;
+        http_client_session_draining = true;
+        stop_HttpProxyServer();
       }
 
       Debug("server", "received exit signal, shutting down in %" PRId64 "secs", timeout);

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -281,7 +281,9 @@ public:
 
       if (timeout) {
         http_client_session_draining = true;
-        stop_HttpProxyServer();
+        if (!remote_management_flag) {
+          stop_HttpProxyServer();
+        }
       }
 
       Debug("server", "received exit signal, shutting down in %" PRId64 "secs", timeout);

--- a/proxy/Main.cc
+++ b/proxy/Main.cc
@@ -277,12 +277,14 @@ public:
       signal_received[SIGINT]  = false;
 
       RecInt timeout = 0;
-      REC_ReadConfigInteger(timeout, "proxy.config.stop.shutdown_timeout");
-
-      if (timeout) {
+      if (RecGetRecordInt("proxy.config.stop.shutdown_timeout", &timeout) == REC_ERR_OKAY && timeout) {
         http_client_session_draining = true;
         if (!remote_management_flag) {
-          stop_HttpProxyServer();
+          // Close listening sockets here only if TS is running standalone
+          RecInt close_sockets = 0;
+          if (RecGetRecordInt("proxy.config.restart.stop_listening", &close_sockets) == REC_ERR_OKAY && close_sockets) {
+            stop_HttpProxyServer();
+          }
         }
       }
 

--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -25,8 +25,6 @@
 #include "HttpDebugNames.h"
 #include "ProxyClientSession.h"
 
-volatile bool http_client_session_draining = false;
-
 static int64_t next_cs_id = 0;
 
 ProxyClientSession::ProxyClientSession() : VConnection(nullptr)

--- a/proxy/ProxyClientSession.cc
+++ b/proxy/ProxyClientSession.cc
@@ -25,6 +25,8 @@
 #include "HttpDebugNames.h"
 #include "ProxyClientSession.h"
 
+volatile bool http_client_session_draining = false;
+
 static int64_t next_cs_id = 0;
 
 ProxyClientSession::ProxyClientSession() : VConnection(nullptr)

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -31,8 +31,6 @@
 #include "InkAPIInternal.h"
 #include "http/HttpServerSession.h"
 
-extern volatile bool http_client_session_draining;
-
 // Emit a debug message conditional on whether this particular client session
 // has debugging enabled. This should only be called from within a client session
 // member function.
@@ -125,7 +123,11 @@ public:
   bool
   is_draining() const
   {
-    return http_client_session_draining;
+    RecInt draining;
+    if (RecGetRecordInt("proxy.node.config.draining", &draining) != REC_ERR_OKAY) {
+      return false;
+    }
+    return draining != 0;
   }
 
   // Initiate an API hook invocation.

--- a/proxy/ProxyClientSession.h
+++ b/proxy/ProxyClientSession.h
@@ -31,6 +31,8 @@
 #include "InkAPIInternal.h"
 #include "http/HttpServerSession.h"
 
+extern volatile bool http_client_session_draining;
+
 // Emit a debug message conditional on whether this particular client session
 // has debugging enabled. This should only be called from within a client session
 // member function.
@@ -118,6 +120,12 @@ public:
   is_active() const
   {
     return m_active;
+  }
+
+  bool
+  is_draining() const
+  {
+    return http_client_session_draining;
   }
 
   // Initiate an API hook invocation.

--- a/proxy/http/HttpProxyServerMain.cc
+++ b/proxy/http/HttpProxyServerMain.cc
@@ -331,3 +331,10 @@ start_HttpProxyServerBackDoor(int port, int accept_threads)
   // The backdoor only binds the loopback interface
   netProcessor.main_accept(new HttpSessionAccept(ha_opt), NO_FD, opt);
 }
+
+void
+stop_HttpProxyServer()
+{
+  sslNetProcessor.stop_accept();
+  netProcessor.stop_accept();
+}

--- a/proxy/http/HttpProxyServerMain.h
+++ b/proxy/http/HttpProxyServerMain.h
@@ -35,6 +35,8 @@ void init_accept_HttpProxyServer(int n_accept_threads = 0);
 */
 void start_HttpProxyServer();
 
+void stop_HttpProxyServer();
+
 void start_HttpProxyServerBackDoor(int port, int accept_threads = 0);
 
 NetProcessor::AcceptOptions make_net_accept_options(const HttpProxyPort *port, unsigned nthreads);

--- a/proxy/http/HttpTransact.cc
+++ b/proxy/http/HttpTransact.cc
@@ -7801,6 +7801,10 @@ HttpTransact::build_response(State *s, HTTPHdr *base_response, HTTPHdr *outgoing
 
   HttpTransactHeaders::add_server_header_to_response(s->txn_conf, outgoing_response);
 
+  if (s->state_machine->ua_session && s->state_machine->ua_session->get_parent()->is_draining()) {
+    HttpTransactHeaders::add_connection_close(outgoing_response);
+  }
+
   if (!s->cop_test_page && is_debug_tag_set("http_hdrs")) {
     if (base_response) {
       DUMP_HEADER("http_hdrs", base_response, s->state_machine_id, "Base Header for Building Response");

--- a/proxy/http/HttpTransactHeaders.cc
+++ b/proxy/http/HttpTransactHeaders.cc
@@ -1317,3 +1317,14 @@ HttpTransactHeaders::normalize_accept_encoding(const OverridableHttpConfigParams
     }
   }
 }
+
+void
+HttpTransactHeaders::add_connection_close(HTTPHdr *header)
+{
+  MIMEField *field = header->field_find(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
+  if (!field) {
+    field = header->field_create(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
+    header->field_attach(field);
+  }
+  header->field_value_set(field, HTTP_VALUE_CLOSE, HTTP_LEN_CLOSE);
+}

--- a/proxy/http/HttpTransactHeaders.h
+++ b/proxy/http/HttpTransactHeaders.h
@@ -95,6 +95,7 @@ public:
   static void add_server_header_to_response(OverridableHttpConfigParams *http_txn_conf, HTTPHdr *header);
   static void remove_privacy_headers_from_request(HttpConfigParams *http_config_param, OverridableHttpConfigParams *http_txn_conf,
                                                   HTTPHdr *header);
+  static void add_connection_close(HTTPHdr *header);
 
   static int nstrcpy(char *d, const char *as);
 };

--- a/proxy/http2/HTTP2.cc
+++ b/proxy/http2/HTTP2.cc
@@ -28,8 +28,6 @@
 #include "P_RecCore.h"
 #include "P_RecProcess.h"
 
-bool http2_drain = false;
-
 const char *const HTTP2_CONNECTION_PREFACE = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 // Constant strings for pseudo headers

--- a/proxy/http2/HTTP2.h
+++ b/proxy/http2/HTTP2.h
@@ -38,8 +38,6 @@ typedef unsigned Http2StreamId;
 // the flow control window can be come negative so we need to track it with a signed type.
 typedef int32_t Http2WindowSize;
 
-extern bool http2_drain;
-
 extern const char *const HTTP2_CONNECTION_PREFACE;
 const size_t HTTP2_CONNECTION_PREFACE_LEN = 24;
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -303,15 +303,6 @@ Http2ClientSession::main_event_handler(int event, void *edata)
     schedule_event = nullptr;
   }
 
-  // For a case we already checked Connection header and it didn't exist
-  if (this->is_draining() && this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
-    this->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED);
-  }
-
-  if (this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NOT_INITIATED) {
-    send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_SHUTDOWN_INIT, this);
-  }
-
   switch (event) {
   case VC_EVENT_READ_COMPLETE:
   case VC_EVENT_READ_READY:
@@ -351,6 +342,16 @@ Http2ClientSession::main_event_handler(int event, void *edata)
     retval = 0;
     break;
   }
+
+  // For a case we already checked Connection header and it didn't exist
+  if (this->is_draining() && this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
+    this->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED);
+  }
+
+  if (this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NOT_INITIATED) {
+    send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_SHUTDOWN_INIT, this);
+  }
+
   recursion--;
   if (!connection_state.is_recursing() && this->recursion == 0 && kill_me) {
     this->free();

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -303,7 +303,12 @@ Http2ClientSession::main_event_handler(int event, void *edata)
     schedule_event = nullptr;
   }
 
-  if (http2_drain && this->connection_state.get_shutdown_state() == NOT_INITIATED) {
+  // For a case we already checked Connection header and it didn't exist
+  if (this->is_draining() && this->connection_state.get_shutdown_state() == NOT_PLANNED) {
+    this->connection_state.set_shutdown_state(NOT_INITIATED);
+  }
+
+  if (this->connection_state.get_shutdown_state() == NOT_INITIATED) {
     send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_SHUTDOWN_INIT, this);
   }
 

--- a/proxy/http2/Http2ClientSession.cc
+++ b/proxy/http2/Http2ClientSession.cc
@@ -304,11 +304,11 @@ Http2ClientSession::main_event_handler(int event, void *edata)
   }
 
   // For a case we already checked Connection header and it didn't exist
-  if (this->is_draining() && this->connection_state.get_shutdown_state() == NOT_PLANNED) {
-    this->connection_state.set_shutdown_state(NOT_INITIATED);
+  if (this->is_draining() && this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
+    this->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED);
   }
 
-  if (this->connection_state.get_shutdown_state() == NOT_INITIATED) {
+  if (this->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NOT_INITIATED) {
     send_connection_event(&this->connection_state, HTTP2_SESSION_EVENT_SHUTDOWN_INIT, this);
   }
 

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -927,8 +927,8 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
 
   // Initiate a gracefull shutdown
   case HTTP2_SESSION_EVENT_SHUTDOWN_INIT: {
-    ink_assert(shutdown_state == NOT_INITIATED);
-    shutdown_state = INITIATED;
+    ink_assert(shutdown_state == HTTP2_SHUTDOWN_NOT_INITIATED);
+    shutdown_state = HTTP2_SHUTDOWN_INITIATED;
     // [RFC 7540] 6.8.  GOAWAY
     // A server that is attempting to gracefully shut down a
     // connection SHOULD send an initial GOAWAY frame with the last stream
@@ -940,8 +940,8 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
 
   // Continue a gracefull shutdown
   case HTTP2_SESSION_EVENT_SHUTDOWN_CONT: {
-    ink_assert(shutdown_state == INITIATED);
-    shutdown_state = IN_PROGRESS;
+    ink_assert(shutdown_state == HTTP2_SHUTDOWN_INITIATED);
+    shutdown_state = HTTP2_SHUTDOWN_IN_PROGRESS;
     // [RFC 7540] 6.8.  GOAWAY
     // ..., the server can send another GOAWAY frame with an updated last stream identifier
     send_goaway_frame(latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_NO_ERROR);
@@ -1166,7 +1166,7 @@ Http2ConnectionState::release_stream(Http2Stream *stream)
         // We were shutting down, go ahead and terminate the session
         ua_session->destroy();
         ua_session = nullptr;
-      } else if (shutdown_state == IN_PROGRESS) {
+      } else if (shutdown_state == HTTP2_SHUTDOWN_IN_PROGRESS) {
         this_ethread()->schedule_imm_local((Continuation *)this, HTTP2_SESSION_EVENT_FINI);
       }
     }

--- a/proxy/http2/Http2ConnectionState.cc
+++ b/proxy/http2/Http2ConnectionState.cc
@@ -935,13 +935,14 @@ Http2ConnectionState::main_event_handler(int event, void *edata)
     // identifier set to 2^31-1 and a NO_ERROR code.
     send_goaway_frame(INT32_MAX, Http2ErrorCode::HTTP2_ERROR_NO_ERROR);
     // After allowing time for any in-flight stream creation (at least one round-trip time),
-    this_ethread()->schedule_in((Continuation *)this, HRTIME_SECONDS(2), HTTP2_SESSION_EVENT_SHUTDOWN_CONT);
+    shutdown_cont_event = this_ethread()->schedule_in((Continuation *)this, HRTIME_SECONDS(2), HTTP2_SESSION_EVENT_SHUTDOWN_CONT);
   } break;
 
   // Continue a gracefull shutdown
   case HTTP2_SESSION_EVENT_SHUTDOWN_CONT: {
     ink_assert(shutdown_state == HTTP2_SHUTDOWN_INITIATED);
-    shutdown_state = HTTP2_SHUTDOWN_IN_PROGRESS;
+    shutdown_cont_event = nullptr;
+    shutdown_state      = HTTP2_SHUTDOWN_IN_PROGRESS;
     // [RFC 7540] 6.8.  GOAWAY
     // ..., the server can send another GOAWAY frame with an updated last stream identifier
     send_goaway_frame(latest_streamid_in, Http2ErrorCode::HTTP2_ERROR_NO_ERROR);

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -138,6 +138,9 @@ public:
   void
   destroy()
   {
+    if (shutdown_cont_event) {
+      shutdown_cont_event->cancel();
+    }
     cleanup_streams();
 
     mutex = nullptr; // magic happens - assigning to nullptr frees the ProxyMutex
@@ -301,6 +304,7 @@ private:
   bool fini_received                = false;
   int recursion                     = 0;
   Http2ShutdownState shutdown_state = HTTP2_SHUTDOWN_NONE;
+  Event *shutdown_cont_event        = nullptr;
 };
 
 #endif // __HTTP2_CONNECTION_STATE_H__

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -38,7 +38,7 @@ enum Http2SendADataFrameResult {
   HTTP2_SEND_A_DATA_FRAME_DONE       = 3,
 };
 
-enum Http2ShutdownState { NOT_PLANNED, NOT_INITIATED, INITIATED, IN_PROGRESS };
+enum Http2ShutdownState { HTTP2_SHUTDOWN_NONE, HTTP2_SHUTDOWN_NOT_INITIATED, HTTP2_SHUTDOWN_INITIATED, HTTP2_SHUTDOWN_IN_PROGRESS };
 
 class Http2ConnectionSettings
 {
@@ -300,7 +300,7 @@ private:
   bool _scheduled                   = false;
   bool fini_received                = false;
   int recursion                     = 0;
-  Http2ShutdownState shutdown_state = NOT_PLANNED;
+  Http2ShutdownState shutdown_state = HTTP2_SHUTDOWN_NONE;
 };
 
 #endif // __HTTP2_CONNECTION_STATE_H__

--- a/proxy/http2/Http2ConnectionState.h
+++ b/proxy/http2/Http2ConnectionState.h
@@ -38,7 +38,7 @@ enum Http2SendADataFrameResult {
   HTTP2_SEND_A_DATA_FRAME_DONE       = 3,
 };
 
-enum Http2ShutdownState { NOT_INITIATED, INITIATED, IN_PROGRESS };
+enum Http2ShutdownState { NOT_PLANNED, NOT_INITIATED, INITIATED, IN_PROGRESS };
 
 class Http2ConnectionSettings
 {
@@ -300,7 +300,7 @@ private:
   bool _scheduled                   = false;
   bool fini_received                = false;
   int recursion                     = 0;
-  Http2ShutdownState shutdown_state = NOT_INITIATED;
+  Http2ShutdownState shutdown_state = NOT_PLANNED;
 };
 
 #endif // __HTTP2_CONNECTION_STATE_H__

--- a/proxy/http2/Http2SessionAccept.cc
+++ b/proxy/http2/Http2SessionAccept.cc
@@ -46,10 +46,6 @@ Http2SessionAccept::accept(NetVConnection *netvc, MIOBuffer *iobuf, IOBufferRead
     return false;
   }
 
-  if (http2_drain) {
-    return false;
-  }
-
   netvc->attributes = this->options.transport_type;
 
   if (is_debug_tag_set("http2_seq")) {

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -555,6 +555,19 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
       case PARSE_RESULT_DONE: {
         this->response_header_done = true;
 
+        // Schedule session shutdown if response header has "Connection: close"
+        MIMEField *field = this->response_header.field_find(MIME_FIELD_CONNECTION, MIME_LEN_CONNECTION);
+        if (field) {
+          int len;
+          const char *value = field->value_get(&len);
+          if (memcmp(HTTP_VALUE_CLOSE, value, HTTP_LEN_CLOSE) == 0) {
+            SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
+            if (parent->connection_state.get_shutdown_state() == NOT_PLANNED) {
+              parent->connection_state.set_shutdown_state(NOT_INITIATED);
+            }
+          }
+        }
+
         // Send the response header back
         parent->connection_state.send_headers_frame(this);
 

--- a/proxy/http2/Http2Stream.cc
+++ b/proxy/http2/Http2Stream.cc
@@ -562,8 +562,8 @@ Http2Stream::update_write_request(IOBufferReader *buf_reader, int64_t write_len,
           const char *value = field->value_get(&len);
           if (memcmp(HTTP_VALUE_CLOSE, value, HTTP_LEN_CLOSE) == 0) {
             SCOPED_MUTEX_LOCK(lock, this->mutex, this_ethread());
-            if (parent->connection_state.get_shutdown_state() == NOT_PLANNED) {
-              parent->connection_state.set_shutdown_state(NOT_INITIATED);
+            if (parent->connection_state.get_shutdown_state() == HTTP2_SHUTDOWN_NONE) {
+              parent->connection_state.set_shutdown_state(HTTP2_SHUTDOWN_NOT_INITIATED);
             }
           }
         }

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -153,7 +153,7 @@ public:
   void reenable(VIO *vio) override;
   virtual void transaction_done() override;
   virtual bool
-  ignore_keep_alive()
+  ignore_keep_alive() override
   {
     return false;
   }

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -152,6 +152,12 @@ public:
   bool update_write_request(IOBufferReader *buf_reader, int64_t write_len, bool send_update);
   void reenable(VIO *vio) override;
   virtual void transaction_done() override;
+  virtual bool
+  ignore_keep_alive()
+  {
+    return false;
+  }
+
   void send_response_body();
   void push_promise(URL &url, const MIMEField *accept_encoding);
 

--- a/proxy/http2/Http2Stream.h
+++ b/proxy/http2/Http2Stream.h
@@ -155,6 +155,8 @@ public:
   virtual bool
   ignore_keep_alive() override
   {
+    // If we return true here, Connection header will always be "close".
+    // It should be handled as the same as HTTP/1.1
     return false;
   }
 

--- a/proxy/shared/UglyLogStubs.cc
+++ b/proxy/shared/UglyLogStubs.cc
@@ -161,6 +161,12 @@ NetProcessor::main_accept(Continuation * /* cont ATS_UNUSED */, SOCKET /* fd ATS
   return nullptr;
 }
 
+void
+NetProcessor::stop_accept()
+{
+  ink_release_assert(false);
+}
+
 Action *
 UnixNetProcessor::accept_internal(Continuation * /* cont ATS_UNUSED */, int /* fd ATS_UNUSED */,
                                   AcceptOptions const & /* opt ATS_UNUSED */)


### PR DESCRIPTION
This is based on https://github.com/apache/trafficserver/pull/2106, and adds support for "traffic_ctl stop --drain".

- Add "--drain" option to "traffic_ctl stop" command
- Add mnagement API "TSStop"
- Add management event "MGMT_EVENT_DRAIN"
- Use "proxy.node.config.draining" instead of a global variable

I haven't tested this branch yet at all, and I'm unfamiliar with this area.
Please feel free to leave your comments and thoughts.